### PR TITLE
Use sqlite3 malloc/free

### DIFF
--- a/src/libsqlite3roaring.c
+++ b/src/libsqlite3roaring.c
@@ -12,7 +12,7 @@ static void roaringFreeFunc(roaring_bitmap_t *p){
 
 
 static void roaringArrayFreeFunc(int *p){
-  free(p);
+  sqlite3_free(p);
 }
 
 /*********************************************
@@ -34,7 +34,7 @@ static void roaringCreateFunc(
     roaring_bitmap_add(r, sqlite3_value_int(argv[i]));
   }
   int nSize = (int )roaring_bitmap_size_in_bytes(r);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   int nOut = (int) roaring_bitmap_serialize(r, pOut);
   roaring_bitmap_free(r);  
   sqlite3_result_blob(context, pOut, nOut, sqlite3_free); 
@@ -95,7 +95,7 @@ static void roaringCreateFinal(sqlite3_context *context){
     rc->rb = roaring_bitmap_create();    
   }
   nSize = (int )roaring_bitmap_size_in_bytes(rc->rb);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(rc->rb, pOut);
   roaring_bitmap_free(rc->rb); 
   memset(rc, 0, sizeof(*rc)); 
@@ -135,7 +135,7 @@ static void roaringAddFunc(
   }
   roaring_bitmap_add(r, sqlite3_value_int(argv[1]));
   int nSize = (int) roaring_bitmap_size_in_bytes(r);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   int nOut = (int) roaring_bitmap_serialize(r, pOut);
   roaring_bitmap_free(r);  
   sqlite3_result_blob(context, pOut, nOut, sqlite3_free);  
@@ -166,7 +166,7 @@ static void roaringRemoveFunc(
   }
   roaring_bitmap_remove(r, sqlite3_value_int(argv[1]));
   int nSize = (int) roaring_bitmap_size_in_bytes(r);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   int nOut = (int) roaring_bitmap_serialize(r, pOut);
   roaring_bitmap_free(r);  
   sqlite3_result_blob(context, pOut, nOut, sqlite3_free);  
@@ -237,7 +237,7 @@ static void roaringAndManyFunc(
     rfinal = roaring_bitmap_create();
   }
   int nSize = (int )roaring_bitmap_size_in_bytes(rfinal);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   int nOut = (int) roaring_bitmap_serialize(rfinal, pOut);
   roaring_bitmap_free(rfinal);  
   sqlite3_result_blob(context, pOut, nOut, sqlite3_free); 
@@ -272,7 +272,7 @@ static void roaringOrManyFunc(
     roaring_bitmap_free(r);
   }
   int nSize = (int )roaring_bitmap_size_in_bytes(rfinal);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   int nOut = (int) roaring_bitmap_serialize(rfinal, pOut);
   roaring_bitmap_free(rfinal);  
   sqlite3_result_blob(context, pOut, nOut, sqlite3_free); 
@@ -307,7 +307,7 @@ static void roaringAndFunc(
   roaring_bitmap_and_inplace(r1, r2);
   int nOut, nSize;
   nSize = (int) roaring_bitmap_size_in_bytes(r1);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(r1, pOut);
   roaring_bitmap_free(r1);  
   roaring_bitmap_free(r2);  
@@ -341,7 +341,7 @@ static void roaringNotFunc(
   roaring_bitmap_andnot_inplace(r1, r2);
   int nOut, nSize;
   nSize = (int) roaring_bitmap_size_in_bytes(r1);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(r1, pOut);
   roaring_bitmap_free(r1);  
   roaring_bitmap_free(r2);  
@@ -406,7 +406,7 @@ static void roaringXorFunc(
   roaring_bitmap_xor_inplace(r1, r2);
   int nOut, nSize;
   nSize = (int) roaring_bitmap_size_in_bytes(r1);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(r1, pOut);
   roaring_bitmap_free(r1);  
   roaring_bitmap_free(r2);  
@@ -501,7 +501,7 @@ static void roaringOrFunc(
   roaring_bitmap_or_inplace(r1, r2);
   int nOut, nSize;
   nSize = (int) roaring_bitmap_size_in_bytes(r1);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(r1, pOut);
   roaring_bitmap_free(r1);  
   roaring_bitmap_free(r2);  
@@ -561,7 +561,7 @@ static void roaringAndAllFinal(sqlite3_context *context){
     rc->rb = roaring_bitmap_create();    
   }
   nSize = (int) roaring_bitmap_size_in_bytes(rc->rb);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(rc->rb, pOut);
   roaring_bitmap_free(rc->rb); 
   memset(rc, 0, sizeof(*rc)); 
@@ -611,7 +611,7 @@ static void roaringOrAllFinal(sqlite3_context *context){
     rc->rb = roaring_bitmap_create();    
   }
   nSize = (int) roaring_bitmap_size_in_bytes(rc->rb);
-  char *pOut = malloc(nSize);
+  char *pOut = sqlite3_malloc(nSize);
   nOut = (int) roaring_bitmap_serialize(rc->rb, pOut);
   roaring_bitmap_free(rc->rb); 
   memset(rc, 0, sizeof(*rc)); 
@@ -651,7 +651,7 @@ static void roaringArrayFunc(
   }
   int nSize = roaring_bitmap_get_cardinality(r);
   uint32_t *ids;
-  ids = malloc(nSize * sizeof(uint32_t));
+  ids = sqlite3_malloc(nSize * sizeof(uint32_t));
   roaring_bitmap_to_uint32_array(r, ids);
   roaring_bitmap_free(r); 
   sqlite3_result_pointer(context, ids, "carray", (void*)roaringArrayFreeFunc);


### PR DESCRIPTION
Hi! Big thanks for creating and sharing this project ❤️ It works fine on my dev machine (M2 MacBook Pro) but I was struggling to get it running in CI — after banging my head against the wall for a while, it looks like it's a memory management issue.

Here's what happens on my CI machine:
```
root@ci2:~/roaringlite# uname -a
Linux ci2 6.1.0-25-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.106-3 (2024-08-26) x86_64 GNU/Linux
root@ci2:~/roaringlite#
root@ci2:~/roaringlite# gcc -g -fPIC -shared libsqlite3roaring.c -o libroaring.so
root@ci2:~/roaringlite# sqlite3 ::memory:: '.load ./libroaring.so' 'SELECT rb_create(1,2,3);'
free(): invalid pointer
Aborted
```

I'm not a C programmer but I tried compiling it with the address sanitizer:
```
root@ci2:~/roaringlite# gcc -g -fPIC -shared -fsanitize=address libsqlite3roaring.c -o libroaring.so
root@ci2:~/roaringlite# LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so sqlite3 ::memory:: '.load ./libroaring.so' 'SELECT rb_create(1,2,3);'

=================================================================
==939323==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x603000000488 in thread T0
    #0 0x7f063feb76a8 in __interceptor_free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7f063fd47c41 in sqlite3_free (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xa6c41)
    #2 0x7f063fd9b928  (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xfa928)
    #3 0x7f063fd9b974  (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xfa974)
    #4 0x7f063fd9659f  (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xf559f)
    #5 0x7f063fd99cb8 in sqlite3VdbeHalt (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xf8cb8)
    #6 0x7f063fd92cc2 in sqlite3VdbeExec (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xf1cc2)
    #7 0x7f063fd9429e in sqlite3_step (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xf329e)
    #8 0x55e53b883801  (/usr/bin/sqlite3+0x20801)
    #9 0x55e53b88b6b4  (/usr/bin/sqlite3+0x286b4)
    #10 0x55e53b86c5c7  (/usr/bin/sqlite3+0x95c7)
    #11 0x7f063fae7249  (/lib/x86_64-linux-gnu/libc.so.6+0x27249)
    #12 0x7f063fae7304 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x27304)
    #13 0x55e53b86d7a0  (/usr/bin/sqlite3+0xa7a0)

0x603000000488 is located 8 bytes to the left of 17-byte region [0x603000000490,0x6030000004a1)
allocated by thread T0 here:
    #0 0x7f063feb89cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f063f0e2f5c in roaringCreateFunc /root/roaringlite/libsqlite3roaring.c:37
    #2 0x7f063fd8c8ec in sqlite3VdbeExec (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xeb8ec)

SUMMARY: AddressSanitizer: bad-free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52 in __interceptor_free
==939323==ABORTING
```
So basically, memory is being freed that hasn't first been malloced. I changed all `malloc` to `sqlite3_malloc` and all all `free` to `sqlite3_free` and now it compiles and runs as expected.

Like I said, I'm not a C programmer, but it worked for me so I figured I'd share.